### PR TITLE
Add environment flags for disabling sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# dr_log
+
+This packages implements a wrapper for `boost::logging`.
+Its interface resembles that of ROS (ie. it uses `DR_INFO("Hello World");` versus `ROS_INFO("Hello World");`).
+
+## Sinks
+
+Sinks in `boost::logging` terms are ways to output the data.
+By default, `dr_log` uses 2 sinks:
+
+- `syslog`
+- `console` (makes use of `std::clog`, which is comparable to `std::cerr`)
+
+The `syslog` sink can be disabled by setting the `DR_LOG_USE_SYSLOG` environment variable to `0`.
+The `console` sink can be disabled by setting the `DR_LOG_USE_CONSOLE` environment variable to `0`.
+
+## Example
+
+```c++
+#include <thread>
+#include <dr_log/dr_log.hpp>
+
+int main() {
+	dr::setupLogging("./test/test.log", "test");
+	DR_DEBUG("Debug" << " message");
+	DR_INFO("Info" << " message");
+	DR_SUCCESS("Succes" << " message");
+	DR_WARN("Warning" << " message");
+	DR_ERROR("Error" << " message");
+	DR_FATAL("Critical" << " message");
+
+	for (int i = 0; i < 10; ++i) {
+		std::this_thread::sleep_for(std::chrono::milliseconds(100));
+		DR_INFO_THROTTLE(2, "Throttled" << " at 2 Hz: " << i);
+	}
+}
+```

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## master -
+### Added
+- Add environment flags for disabling syslog and console outputs (`DR_LOG_USE_SYSLOG` and `DR_LOG_USE_CONSOLE`).
+
+### Changed
+
+### Removed

--- a/src/dr_log.cpp
+++ b/src/dr_log.cpp
@@ -224,9 +224,13 @@ void setupLogging(std::string const & log_file, std::string const & name) {
 	log::add_common_attributes();
 	core->add_global_attribute("Node", log::attributes::constant<std::string>(name));
 
-	// Add  sinks.
-	core->add_sink(createConsoleSink());
-	core->add_sink(createSyslogSink());
+	// Get environment variables to check if we should skip some sinks.
+	char * use_console_sink = std::getenv("DR_LOG_USE_CONSOLE");
+	char * use_syslog_sink  = std::getenv("DR_LOG_USE_SYSLOG");
+
+	// Add sinks.
+	if (!use_console_sink || std::atoi(use_console_sink)) core->add_sink(createConsoleSink());
+	if (!use_syslog_sink  || std::atoi(use_syslog_sink))  core->add_sink(createSyslogSink());
 	if (!log_file.empty()) core->add_sink(createFileSink(log_file));
 
 	// Capture log4cxx output too.


### PR DESCRIPTION
This change adds two environment flags to `dr_log`: `DR_LOG_USE_CONSOLE` and `DR_LOG_USE_SYSLOG`. They can be used to disable console and syslog sinks.

Motivation:
`systemd` captures both the console output and syslog output. We add both as sinks in `dr_log` so messages get logged twice by default. In some services we set `StandardOutput=null` in the `.service` file. This has the effect that the console is not logged by `journald`. However in case of an exception the console output is also ignored and since the exception is not printed using `dr_log`, syslog is not used either. Using this PR we can disable just the console logging of `dr_log` and remove the `StandardOutput=null` in the `.service` files (replacing it with an `Environment="DR_LOG_USE_CONSOLE=0"` argument).

@vsuryamurthy @enricoliscio this could also be interesting for you guys.