### PR TITLE
Prevent warnings if BOOST_LOG defines are already set.

### DIFF
--- a/include/dr_log/dr_log.hpp
+++ b/include/dr_log/dr_log.hpp
@@ -2,8 +2,13 @@
 #include <chrono>
 #include <string>
 
+#ifndef BOOST_LOG_USE_NATIVE_SYSLOG
 #define BOOST_LOG_USE_NATIVE_SYSLOG
+#endif
+
+#ifndef BOOST_LOG_DYN_LINK
 #define BOOST_LOG_DYN_LINK
+#endif
 
 #include <boost/log/common.hpp>
 #include <boost/log/sources/severity_logger.hpp>


### PR DESCRIPTION
These cause compiler warnings if they have been set before. Not sure who changed it (boost headers or cmake), but `BOOST_LOG_DYN_LINK` is already defined by default now.