### PR TITLE
Make ROS integration with log4cxx optional.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,12 +6,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 add_compile_options(-Wall -Wextra -Wpedantic)
 
+set(CACHE DR_LOG_USE_LOG4CXX BOOL OFF "Use log4cxx to intercept log messages from ROS")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")
 
 find_package(catkin REQUIRED COMPONENTS)
 
 find_package(Boost REQUIRED COMPONENTS log log_setup system date_time thread)
-find_package(log4cxx REQUIRED)
 
 set(CMAKE_THREAD_PREFER_PTHREAD ON)
 find_package(Threads)
@@ -25,12 +26,19 @@ include_directories(include/${PROJECT_NAME})
 include_directories(SYSTEM
 	${catkin_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS}
-	${log4cxx_INCLUDE_DIRS}
 )
 
-add_library(${PROJECT_NAME}
+set(log4cxx_source_files "")
+if (DR_LOG_USE_LOG4CXX)
+	find_package(log4cxx REQUIRED)
+	include_directories(SYSTEM log4cxx_INCLUDE_DIRS)
+	list(APPEND log4cxx_source_files src/log4cxx.cpp)
+	add_definitions(-DDR_LOG_USE_LOG4CXX)
+endif()
+
+add_library(${PROJECT_NAME} ${log4cxx_source_files}
 	src/dr_log.cpp
-	src/log4cxx.cpp
+	${log4cxx_source_files}
 )
 
 add_executable(${PROJECT_NAME}_test src/test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 add_compile_options(-Wall -Wextra -Wpedantic)
+add_link_options(LINKER:--as-needed)
 
 set(CACHE DR_LOG_USE_LOG4CXX BOOL OFF "Use log4cxx to intercept log messages from ROS")
 

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -4,17 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master -
-### Added
-- Add environment flags for disabling syslog and console outputs (`DR_LOG_USE_SYSLOG` and `DR_LOG_USE_CONSOLE`).
-
 ### Changed
-
-### Removed
+- Make ROS integration with log4cxx optional.
 
 ## 0.1.3 - 2020-02-24
 ### Added
 - Add environment flags for disabling syslog and console outputs (`DR_LOG_USE_SYSLOG` and `DR_LOG_USE_CONSOLE`).
-
-### Changed
-
-### Removed

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ## master -
 ### Changed
 - Make ROS integration with log4cxx optional.
+- Link with --as-needed.
 
 ## 0.1.3 - 2020-02-24
 ### Added

--- a/include/dr_log/dr_log.hpp
+++ b/include/dr_log/dr_log.hpp
@@ -70,6 +70,4 @@ void setupLogging(
 	std::string const & name      ///< The name of the program or node for logging purposes.
 );
 
-void registerLog4cxxAppenders();
-
 }

--- a/src/dr_log.cpp
+++ b/src/dr_log.cpp
@@ -212,6 +212,10 @@ std::ostream & operator<< (std::ostream & stream, LogLevel level) {
 	return stream;
 }
 
+#ifdef DR_LOG_USE_LOG4CXX
+void registerLog4cxxAppenders();
+#endif
+
 void setupLogging(std::string const & log_file, std::string const & name) {
 	if (logging_initialized.test_and_set()) {
 		DR_ERROR("dr::setupLogging() called while logging has already been initialized.");
@@ -233,8 +237,10 @@ void setupLogging(std::string const & log_file, std::string const & name) {
 	if (!use_syslog_sink  || std::atoi(use_syslog_sink))  core->add_sink(createSyslogSink());
 	if (!log_file.empty()) core->add_sink(createFileSink(log_file));
 
+#ifdef DR_LOG_USE_LOG4CXX
 	// Capture log4cxx output too.
 	registerLog4cxxAppenders();
+#endif
 }
 
 }


### PR DESCRIPTION
Because `log4cxx` pulls in `libgdm` and `libdb`, which are GPL licensed.