### PR TITLE
Automatically flush output streams after each log record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## master -
+### Fixed
+- Prevent output buffering from delaying log messages when stderr is redirected.
 
 ## 0.3.0 - 2020-11-02
 ### Added

--- a/src/dr_log.cpp
+++ b/src/dr_log.cpp
@@ -184,6 +184,7 @@ namespace {
 	boost::shared_ptr<log::sinks::synchronous_sink<log::sinks::basic_text_ostream_backend<char>>> createConsoleSink() {
 		auto backend = boost::make_shared<log::sinks::text_ostream_backend>();
 		backend->add_stream(boost::shared_ptr<std::ostream>(&std::clog, NullDeleter()));
+		backend->auto_flush(true);
 		auto frontend = boost::make_shared<log::sinks::synchronous_sink<log::sinks::text_ostream_backend>>(backend);
 		frontend->set_formatter(makeAnsiColorFormatter(text_format));
 		return frontend;
@@ -193,6 +194,7 @@ namespace {
 	boost::shared_ptr<log::sinks::synchronous_sink<log::sinks::basic_text_ostream_backend<char>>> createSystemdSink() {
 		auto backend = boost::make_shared<log::sinks::text_ostream_backend>();
 		backend->add_stream(boost::shared_ptr<std::ostream>(&std::clog, NullDeleter()));
+		backend->auto_flush(true);
 
 		auto frontend = boost::make_shared<log::sinks::synchronous_sink<log::sinks::text_ostream_backend>>(backend);
 		frontend->set_formatter(systemd_format);


### PR DESCRIPTION
To prevent block buffering from delaying log output when stderr is captured.